### PR TITLE
Upgrade to use Kustomize v4+

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,11 +33,11 @@ uninstall: kustomize
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: kustomize
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build --load_restrictor none config/${OVERLAY} | kubectl apply -f -
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/${OVERLAY} | kubectl apply -f -
 
 # Undeploy controller in the configured Kubernetes cluster in ~/.kube/config
 undeploy: kustomize
-	$(KUSTOMIZE) build --load_restrictor none config/${OVERLAY} | kubectl delete -f -
+	$(KUSTOMIZE) build --load-restrictor LoadRestrictionsNone config/${OVERLAY} | kubectl delete -f -
 
 # Build the docker image
 docker-build:


### PR DESCRIPTION
using the current code leads to the following error:

`Logging initialized 20220214T130350
/usr/local/bin/kubectl
NAME          STATUS   ROLES           AGE   VERSION
10.243.64.4   Ready    master,worker   75d   v1.21.4+6438632
10.243.64.5   Ready    master,worker   75d   v1.21.4+6438632
/usr/local/bin/kustomize build config/crd | kubectl apply -f -
customresourcedefinition.apiextensions.k8s.io/sonarqubes.redhatgov.io created
cd config/manager && /usr/local/bin/kustomize edit set image controller=quay.io/redhatgov/sonarqube-operator:latest
/usr/local/bin/kustomize build --load_restrictor none config/default | kubectl apply -f -
Error: unknown flag: --load_restrictor
error: no objects passed to apply
make: *** [deploy] Error 1`

kustomize in newer versions uses a new syntax.